### PR TITLE
Add term annotation for specifying a field as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Lets you hide a value in generated schema
 
         case class MyType(@Term.Hide mySecretField: Int)
 
+### Required
+Lets you specify a value as a required value
+
+        case class MyType(@Term.Required myRequiredField: Int)
+
 Copyright 2014 Coursera Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/scala/org/coursera/autoschema/annotations/annotations.scala
+++ b/src/main/scala/org/coursera/autoschema/annotations/annotations.scala
@@ -116,4 +116,15 @@ object Term {
    */
   @field
   type Description = annotations.Description@field
+
+  /**
+    * Marks the annotated field as a required field
+    * @example
+    * {{{
+    *      case class MyType(@Required myRequiredField: String)
+    * }}}
+    */
+  @field
+  class Required extends StaticAnnotation
+
 }

--- a/src/test/scala/org/coursera/AutoSchema/AutoSchemaTest.scala
+++ b/src/test/scala/org/coursera/AutoSchema/AutoSchemaTest.scala
@@ -57,6 +57,8 @@ case class MutuallyRecursiveTypeTwo(param1: MutuallyRecursiveTypeOne)
 @Description("Type description")
 case class TypeWithDescription(@Term.Description("Parameter description") param1: String)
 
+case class TypeWithRequired(@Term.Required param1: String)
+
 class AutoSchemaTest extends AssertionsForJUnit {
   @Test
   def justAnInt: Unit = {
@@ -218,5 +220,17 @@ class AutoSchemaTest extends AssertionsForJUnit {
             "type" -> "string",
             "description" -> "Parameter description")),
         "description" -> "Type description"))
+  }
+
+  @Test
+  def typeWithRequired: Unit = {
+    assert(createSchema[TypeWithRequired] ===
+      Json.obj(
+        "title" -> "TypeWithRequired",
+        "type" -> "object",
+        "properties" -> Json.obj(
+          "param1" -> Json.obj(
+            "type" -> "string",
+            "required" -> true))))
   }
 }


### PR DESCRIPTION
New field term annotation that allows one to specify whether a field is required or not (e.g. for a UI to validate a required field)
